### PR TITLE
Kündigungs-Initiative

### DIFF
--- a/bundesverfassung.rst
+++ b/bundesverfassung.rst
@@ -2773,6 +2773,18 @@ werden, die gegen diesen Artikel verstossen.
 
 | 
 
+
+**Art. 121** *b* Zuwanderung ohne Personenfreizügigkeit
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+:sup:`1`  Die Schweiz regelt die Zuwanderung von Ausländerinnen und Ausländern eigenständig.
+
+:sup:`2`  Es dürfen keine neuen völkerrechtlichen Verträge abgeschlossen und keine anderen neuen völkerrechtlichen Verpflichtungen eingegangen werden, welche ausländischen Staatsangehörigen eine Personenfreizügigkeit gewähren.
+
+:sup:`3`  Bestehende völkerrechtliche Verträge und andere völkerrechtliche Verpflichtungen dürfen nicht im Widerspruch zu den Absätzen 1 und 2 angepasst oder erweitert werden.
+
+
+
 10. Abschnitt: Zivilrecht, Strafrecht, Messwesen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -4587,6 +4599,15 @@ neu zu verhandeln und anzupassen.
 nach dessen Annahme durch Volk und Stände noch nicht in Kraft getreten,
 so erlässt der Bundesrat auf diesen Zeitpunkt hin die
 Ausführungsbestimmungen vorübergehend auf dem Verordnungsweg.
+
+
+*12.* Übergangsbestimmungen zu Art. 121b (Zuwanderung ohne Personenfreizügigkeit)
+
+:sup:`1`  Auf dem Verhandlungsweg ist anzustreben, dass das Abkommen vom 21. Juni 19993 zwischen der Schweizerischen Eidgenossenschaft einerseits und der Europäischen Gemeinschaft und ihren Mitgliedstaaten andererseits über die Freizügigkeit innerhalb von zwölf Monaten nach Annahme von Artikel 121b durch Volk und Stände ausser Kraft ist.
+
+:sup:`2`  Gelingt dies nicht, so kündigt der Bundesrat das Abkommen nach Absatz 1 innert weiteren 30 Tagen.
+
+
 
 --------------
 


### PR DESCRIPTION
# Zu viel ist zu viel – wir wollen keine 10-Millionen-Schweiz!

Tatsache ist: Die Schweiz ist ein kleines Land! Tatsache ist auch: In ein kleines Land können
sich nicht immer mehr Menschen hineinzwängen! Doch genau das passiert seit 2007: Seit der Einführung der Personenfreizügigkeit mit der EU haben wir unsere Grenzen für über 500 Millionen Menschen aus der EU geöffnet, ohne dass wir kontrollieren können, wie viele in die Schweiz kommen. In den letzten 13 Jahren sind deshalb bereits 1 Million Menschen zusätzlich in unser Land gekommen. Und jedes Jahr kommen im Durchschnitt nochmals 50'000 Menschen – so viele wie in der Stadt Biel leben – allein aus der EU dazu! Kein Wunder platzt unser kleines Land aus allen Nähten! Das können wir mit einem JA zur Kündigungs-Initiative stoppen. 

